### PR TITLE
Revise the depth sensing API

### DIFF
--- a/explainer.md
+++ b/explainer.md
@@ -184,7 +184,7 @@ enum XRDepthSensingUsage {
   "gpu-optimized"
 };
 
-enum XRDepthFormat {
+enum XRDepthDataFormat {
   // Has to be supported everywhere:
   "luminance-alpha", // internal_format = LUMINANCE_ALPHA, type = UNSIGNED_BYTE,
                      // 2 bytes per pixel, unpack via dot([R, A], [255.0, 256*255.0])
@@ -192,22 +192,22 @@ enum XRDepthFormat {
   "float32",         // internal_format = R32F, type = FLOAT
 };
 
-// Post-session-creation, the depth sensing state needs to be configured
-// with the desired data format.
+// At session creation, the depth sensing API needs to be configured
+// with the desired usage and data format. The user agent will first select
+// the lowest-indexed depth sensing usage that it supports, and then attempt
+// to select the lowest-indexed depth data format. If the user agent is
+// unable to select usage and data format that it supports, the depth sensing
+// will not be enabled on a session - for sessions where depth sensing is
+// listed as required feature, the session creation will fail.
 dictionary XRDepthSensingStateInit {
-  XRDepthSensingUsage usage = "cpu-optimized";
-  XRDepthFormat depthFormat = "luminance-alpha";
+  sequence<XRDepthSensingUsage> depthSensingUsagePreference;
+  sequence<XRDepthDataFormat> depthDataFormatPreference;
 };
 
 partial interface XRSession {
   // Non-null iff depth-sensing is enabled:
-  readonly attribute XRDepthFormat? preferredDepthFormat;
-  readonly attribute XRDepthSensingUsage? preferredDepthSensingUsage;
-
-  // Can be called iff depth-sensing is enabled, will throw if unsupported format is passed in.
-  // The user agent can reject session creation if the desired usage is not supported.
-  // The user agent can support reconfiguring a session, but that is not required.
-  Promise<void> updateDepthSensingState(optional XRDepthSensingStateInit state = {});
+  readonly attribute XRDepthDataFormat? depthDataFormat;
+  readonly attribute XRDepthSensingUsage? depthSensingUsage;
 };
 
 partial interface XRFrame {

--- a/explainer.md
+++ b/explainer.md
@@ -23,7 +23,22 @@ const session = await navigator.xr.requestSession(“immersive-ar”, {
 });
 ```
 
-2. In requestAnimationFrame callback, query XRFrame for the currently available XRDepthInformation:
+2. Configure the session to set the depth sensing usage and data format.
+
+The application can query the user agent's preferred usage (`"cpu-optimized"` or `"gpu-optimized"`) and format (`"luminance-alpha"` or `"float32"`) by accessing `session.preferredDepthSensingUsage` & `session.preferredDepthFormat`:
+
+```javascript
+await session.updateDepthSensingState({
+  usage: session.preferredDepthSensingUsage,
+  depthFormat: session.preferredDepthFormat
+});
+```
+
+Alternatively, the application can configure the depth sensing API using the usage and format that suits its needs, but that may result in the extra work done by the user agent in case the specified usage and format does not match the underlying platform's preferences.
+
+In addition, only the `"luminance-alpha"` data format is guaranteed to be supported. User agents can optionally support more formats if they choose  so.
+
+3. Within requestAnimationFrame() callback, query XRFrame for the currently available XRDepthInformation:
 
 ```javascript
 const view = ...;  // Obtained from a viewer pose.
@@ -34,17 +49,19 @@ if(depthInfo == null) {
 }
 ```
 
-3. Use the data:
-  - CPU access:
+**Note**: the depth information will not be retrievable until the session is successfully configured via the `updateDepthSensingState()` method.
+
+4. Use the data. Irrespective of the usage, `XRDepthInformation` is only valid within the requestAnimationFrame() callback (i.e. only if the `XRFrame` is `active` and `animated`).
+  - `"cpu-optimized"` usage mode:
 
 ```javascript
 // Obtain the depth at (x, y) depth buffer coordinate:
 const depthInMeters = depthInfo.getDepth(x, y);
 ```
 
-Note: The depth buffer coordinates may not correspond to screen space
+**Note**: The depth buffer coordinates may not correspond to screen space
 coordinates. To convert from depth buffer coordinates, the applications
-can use depthData.normTextureFromNormView matrix. Pseudocode:
+can use `depthData.normTextureFromNormView` matrix. Pseudocode:
 
 ```js
 
@@ -64,28 +81,42 @@ const depth_coordinates_view = [depth_coordinates_view_normalized[0] * viewport.
 // coordinates
 ```
 
- - GPU access:
+Alternatively, the depth data is also available via the `depthInfo.data` attribute. The entries are stored in a row-major order, and the entry size & data format is determined by the depth format set when configuring depth sensing API. The raw values obtained from the buffer can be converted to meters by multiplying the value by `depthInfo.rawValueToMeters`.
+
+For example, to access the data at row `r`, column `c` of the buffer that has `"luminance-alpha"` format, the app can use:
+```js
+const index = c + r * depthInfo.width;
+const depthInMetres = depthInfo.data.getUint16(index) * depthInfo.rawValueToMeters;
+```
+
+If the data format was set to `"float32"`, the data could be accessed similarly (note that the only difference is the `getFloat32()` method used on a `DataView` instance):
+```js
+const index = c + r * depthInfo.width;
+const depthInMetres = depthInfo.data.getFloat32(index) * depthInfo.rawValueToMeters;
+```
+
+Both of the above examples are equivalent to calling `depthInfo.getDepth(c, r)`.
+
+**Note**: `XRDepthInformation`'s `data`, `width` & `height` attributes, and `getDepth()` method are only accessible if the depth API was configured with mode set to `"cpu-optimized"`.
+
+ - `"gpu-optimized"` mode:
 
 ```javascript
 
+const xrWebGLBinding = ...; // XRWebGLBinding created for the current session and GL context
+
 // Grab the information from the XRDepthInformation interface:
 const uvTransform = depthInfo.normTextureFromNormView.matrix;
-const dataBuffer = depthInfo.data;
 
 const program = ...; // Linked WebGLProgam program.
 const u_DepthTextureLocation = gl.getUniformLocation(program, "u_DepthTexture");
 const u_UVTransformLocation = gl.getUniformLocation(program, "u_UVTransform");
+const u_RawValueToMeters = gl.getUniformLocation(program, "u_RawValueToMeters");
 
-// The application could upload the depth information like so:
+// The application can access upload the depth information like so:
+const depthTexture = xrWebGLBinding.getDepthTexture(depthInfo);
 
-// gl.TexImage2D expects Uint8Array when using gl.UNSIGNED_BYTE, convert:
-const depthBuffer = new Uint8Array(dataBuffer.buffer,
-                                   dataBuffer.byteOffset,
-                                   dataBuffer.byteLength);
 gl.bindTexture(gl.TEXTURE_2D, depthTexture);
-gl.TexImage2D(GL_TEXTURE_2D, 0, gl.LUMINANCE_ALPHA, depthInfo.width,
-              depthInfo.height, 0, gl.LUMINANCE_ALPHA, gl.UNSIGNED_BYTE,
-              depthBuffer);
 
 // Subsequently, we need to activate the texture unit (in this case, unit 0),
 // and set depth texture sampler to 0:
@@ -95,34 +126,40 @@ gl.uniform1i(u_DepthTextureLocation, 0);
 // In addition, the UV transform is necessary to correctly index into the depth map:
 gl.uniformMatrix4fv(u_UVTransformLocation, false,
                     uvTransform);
+
+// ... and we also need to send the scaling factor to convert from the raw number to meters:
+gl.uniform1f(u_RawValueToMeters, depthInfo.rawValueToMeters);
 ```
 
-The depth data available to the WebGL shaders will then be packed into luminance and alpha components of the texels. *Note*: data on the GPU is provided in millimetres.
+The depth data available to the WebGL shaders will then be packed into luminance and alpha components of the texels.
 
-In order to access the data in the shader, assuming the texture was bound to a texture unit as above, the applications can then use for example fragment shader:
+In order to access the data in the shader, assuming the texture was bound to a texture unit as above, the applications can then use for example fragment shader. The below code assumes that `"luminance-alpha"` was configured as the data format:
 
 ```c++
 precision mediump float;
 
 uniform sampler2D u_DepthTexture;
 uniform mat4 u_UVTransform;
+uniform float u_RawValueToMeters;
 
 varying vec2 v_TexCoord;  // Computed in vertex shader, based on vertex attributes.
 
-float getDepthInMillimeters(in sampler2D depth_texture, in vec2 uv_coord) {
+float getDepth(in sampler2D depth_texture, in vec2 uv_coord) {
   // Depth is packed into the luminance and alpha components of its texture.
   // The texture is a normalized format, storing millimeters.
   vec2 packedDepth = texture2D(depth_texture, uv_coord).ra;
-  return dot(packedDepth, vec2(255.0, 256.0 * 255.0));
+  return dot(packedDepth, vec2(255.0, 256.0 * 255.0)) * u_RawValueToMeters;
 }
 
 void main(void) {
   vec2 texCoord = (u_UVTransform * vec4(v_TexCoord.xy, 0, 1)).xy;
-  float depthInMillimeters = getDepthInMillimeters(u_DepthTexture, texCoord);
+  float depthInMeters = getDepth(u_DepthTexture, texCoord);
 
   gl_FragColor = ...;
 }
 ```
+
+**Note**: `XRWebGLBinding`'s `getDepthTexture()` method will only return a result if the depth API was configured with mode set to `"gpu-optimized"`. Also note that it is possible for the application to configure the depth API using a data format that cannot be uploaded to the GPU with the provided binding (for example, `"float32"` data format on a WebGL1 context).
 
 ### Interpreting the data
 
@@ -139,20 +176,66 @@ let depthValueInMeters = depthInfo.getDepth(x, y);
 
 ## Appendix: Proposed Web IDL
 
+The comments are left in place to provide additional context on the API to the readers of the IDL and should also be repeated in the explainer text above.
+
 ```webidl
-interface XRDepthInformation {
-  readonly attribute Uint16Array data;
+enum XRDepthSensingUsage {
+  "cpu-optimized",
+  "gpu-optimized"
+};
 
-  readonly attribute unsigned long width;
-  readonly attribute unsigned long height;
+enum XRDepthFormat {
+  // Has to be supported everywhere:
+  "luminance-alpha", // internal_format = LUMINANCE_ALPHA, type = UNSIGNED_BYTE,
+                     // 2 bytes per pixel, unpack via dot([R, A], [255.0, 256*255.0])
+  // Other formats do not have to be supported by the user agents:
+  "float32",         // internal_format = R32F, type = FLOAT
+};
 
-  [SameObject] readonly attribute XRRigidTransform normTextureFromNormView;
+// Post-session-creation, the depth sensing state needs to be configured
+// with the desired data format.
+dictionary XRDepthSensingStateInit {
+  XRDepthSensingUsage usage = "cpu-optimized";
+  XRDepthFormat depthFormat = "luminance-alpha";
+};
 
-  float getDepth(unsigned long column, unsigned long row);
+partial interface XRSession {
+  // Non-null iff depth-sensing is enabled:
+  readonly attribute XRDepthFormat? preferredDepthFormat;
+  readonly attribute XRDepthSensingUsage? preferredDepthSensingUsage;
+
+  // Can be called iff depth-sensing is enabled, will throw if unsupported format is passed in.
+  // The user agent can reject session creation if the desired usage is not supported.
+  // The user agent can support reconfiguring a session, but that is not required.
+  Promise<void> updateDepthSensingState(optional XRDepthSensingStateInit state = {});
 };
 
 partial interface XRFrame {
-  XRDepthInformation getDepthInformation(XRView view);
+  // Throws if depth sensing state was never updated,
+  // returns null if the view does not have a corresponding depth buffer.
+  XRDepthInformation? getDepthInformation(XRView view);
+};
+
+[SecureContext, Exposed=Window]
+interface XRDepthInformation {
+  // All methods / attributes are accessible only when the frame
+  // that the depth information originated from is active and animated.
+
+  [SameObject] readonly attribute DataView data;
+  readonly attribute unsigned long width;
+  readonly attribute unsigned long height;
+
+  float getDepth(unsigned long column, unsigned long row);
+
+  // Must be valid irrespective of initialization hint:
+  [SameObject] readonly attribute XRRigidTransform normTextureFromNormView;
+  readonly attribute float rawValueToMeters;
+};
+
+partial interface XRWebGLBinding {
+  // Must succeed when the depth API was initialized as "gpu-optimized". Otherwise, must throw.
+  // Returns opaque texture, its format is determined by the current depth sensing state.
+  WebGLTexture? getDepthTexture(XRDepthInformation depthInformation);
 };
 ```
 


### PR DESCRIPTION
Notable changes:
- the API now requires configuration
- depending on the configuration, the API exposes either CPU- or
GPU-optimized way to access the depth data
- depending on the configuration, the depth data format can vary