### PR TITLE
Minor spec tweaks

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,8 +14,10 @@ jobs:
 
       - name: Install and Build 🔧 # This example project is built using npm and outputs the result to the 'build' folder. Replace with the commands required to build your project, or remove this step entirely if your site is pre-built.
         run: make
+      - name: Prepare Deploy folder
+        run: mkdir deploy && rsync -av --exclude=.git --exclude=.gitignore --exclude=deploy . deploy/
       - name: Deploy 🚀
         uses: JamesIves/github-pages-deploy-action@4.0.0
         with:
           BRANCH: gh-pages # The branch the action should deploy to.
-          FOLDER: out # The folder the action should deploy.
+          FOLDER: deploy # The folder the action should deploy.

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 env/
-out/
+index.html

--- a/Makefile
+++ b/Makefile
@@ -2,18 +2,12 @@ LOCAL_BIKESHED := $(shell command -v bikeshed 2> /dev/null)
 
 .PHONY: all index.html
 
-all: directories index.html images
-
-directories:
-	mkdir -p out/img
-
-images: img/depth_api_data_explained.png
-	cp img/depth_api_data_explained.png out/img/depth_api_data_explained.png
+all: index.html
 
 index.html: index.bs
 ifndef LOCAL_BIKESHED
 	curl https://api.csswg.org/bikeshed/ -F file=@index.bs -F output=err
-	curl https://api.csswg.org/bikeshed/ -F file=@index.bs -F force=1 > out/index.html | tee
+	curl https://api.csswg.org/bikeshed/ -F file=@index.bs -F force=1 > index.html | tee
 else
-	bikeshed spec index.bs out/index.html
+	bikeshed spec index.bs index.html
 endif

--- a/index.bs
+++ b/index.bs
@@ -336,8 +336,8 @@ When {{XRCPUDepthInformation/getDepthInMeters(x, y)}} method is invoked on an {{
     1. Let |normalizedViewCoordinates| be a vector representing 3-dimensional point in space, with <code>x</code> coordinate set to |x|, <code>y</code> coordinate set to |y|, <code>z</code> coordinate set to <code>0.0</code>, and <code>w</code> coordinate set to <code>1.0</code>.
     1. Let |normalizedDepthCoordinates| be a result of premultiplying |normalizedViewCoordinates| vector from the left by |depthInformation|'s {{XRDepthInformation/normDepthBufferFromNormView}}.
     1. Let |depthCoordinates| be a result of scaling |normalizedDepthCoordinates|, with <code>x</code> coordinate multiplied by |depthInformation|'s {{XRDepthInformation/width}} and <code>y</code> coordinate multiplied by |depthInformation|'s {{XRDepthInformation/height}}.
-    1. Let |column| be the value of |depthCoordinates|' <code>x</code> coordinate, rounded to the nearest integer and clamped to <code>[0, width)</code> range.
-    1. Let |row| be the value of |depthCoordinates|' <code>y</code> coordinate, rounded to the nearest integer and clamped to <code>[0, height)</code> range.
+    1. Let |column| be the value of |depthCoordinates|' <code>x</code> coordinate, truncated to an integer, and clamped to <code>[0, width-1]</code> integer range.
+    1. Let |row| be the value of |depthCoordinates|' <code>y</code> coordinate, truncated to an integer, and clamped to <code>[0, height-1]</code> integer range.
     1. Let |index| be equal to |row| multiplied by {{XRDepthInformation/width}} & added to |column|.
     1. Let |byteIndex| be equal to |index| multiplied by the size of the depth data format.
     1. Let |rawDepth| be equal to a value found at index |byteIndex| in {{XRCPUDepthInformation/data}}, interpreted as a number accordingly to |session|'s {{XRSession/depthDataFormat}}.
@@ -454,7 +454,6 @@ When {{XRWebGLBinding/getDepthInformation(view)}} method is invoked on an {{XRFr
   1. If the |session|'s {{XRSession/depthUsage}} is not {{XRDepthUsage/"gpu-optimized"}}, throw an {{InvalidStateError}} and abort these steps.
   1. If |frame|'s [=XRFrame/active=] boolean is <code>false</code>, throw an {{InvalidStateError}} and abort these steps.
   1. If |frame|'s [=XRFrame/animationFrame=] boolean is <code>false</code>, throw an {{InvalidStateError}} and abort these steps.
-  1. If |frame| does not match |view|'s [=XRView/frame=], [=exception/throw=] an {{InvalidStateError}} and abort these steps.
   1. Let |depthInformation| be a result of [=create a WebGL depth information instance|creating a WebGL depth information instance=] given |frame| and |view|.
   1. Return |depthInformation|.
 


### PR DESCRIPTION
- Remove unnecessary step in one algorithm
- Update getDepthInMeters() to correctly replicate texture sampling on
the CPU - should now be equivalent to GL_NEAREST
- Restore previous versions of Makefile and GH actions' deploy.yml


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/immersive-web/depth-sensing/pull/16.html" title="Last updated on Feb 11, 2021, 10:11 PM UTC (7c5a237)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/immersive-web/depth-sensing/16/760b294...7c5a237.html" title="Last updated on Feb 11, 2021, 10:11 PM UTC (7c5a237)">Diff</a>