### PR TITLE
Fix dataFormatPreference in session start example.

### DIFF
--- a/explainer.md
+++ b/explainer.md
@@ -59,12 +59,12 @@ Alternatively, the depth data is also available via the `depthInfo.data` attribu
 
 For example, to access the data at row `r`, column `c` of the buffer that has `"luminance-alpha"` format, the app can use:
 ```js
-const uint8Data = new Uint8Array(depthInfo.data.buffer,
-                                 depthInfo.data.byteOffset,
-                                 depthInfo.data.byteLength);
+const uint16Data = new Uint16Array(depthInfo.data.buffer,
+                                   depthInfo.data.byteOffset,
+                                   depthInfo.data.byteLength);
 
 const index = c + r * depthInfo.width;
-const depthInMetres = uint8Data[index] * depthInfo.rawValueToMeters;
+const depthInMetres = uint16Data[index] * depthInfo.rawValueToMeters;
 ```
 
 If the data format was set to `"float32"`, the data could be accessed similarly (note that the only difference is that the data buffer is interpreted as containing float32s):
@@ -240,7 +240,7 @@ interface XRCPUDepthInformation : XRDepthInformation {
   // Data format is determined by session's depthDataFormat attribute.
   [SameObject] readonly attribute ArrayBuffer data;
 
-  float getDepthInMeters(unsigned long column, unsigned long row);
+  float getDepthInMeters(float x, float y);
 };
 
 interface XRWebGLDepthInformation : XRDepthInformation {

--- a/explainer.md
+++ b/explainer.md
@@ -59,12 +59,12 @@ Alternatively, the depth data is also available via the `depthInfo.data` attribu
 
 For example, to access the data at row `r`, column `c` of the buffer that has `"luminance-alpha"` format, the app can use:
 ```js
-const uint16Data = new Uint16Array(depthInfo.data.buffer,
-                                   depthInfo.data.byteOffset,
-                                   depthInfo.data.byteLength);
+const uint8Data = new Uint8Array(depthInfo.data.buffer,
+                                 depthInfo.data.byteOffset,
+                                 depthInfo.data.byteLength);
 
 const index = c + r * depthInfo.width;
-const depthInMetres = uint16Data[index] * depthInfo.rawValueToMeters;
+const depthInMetres = uint8Data[index] * depthInfo.rawValueToMeters;
 ```
 
 If the data format was set to `"float32"`, the data could be accessed similarly (note that the only difference is that the data buffer is interpreted as containing float32s):

--- a/explainer.md
+++ b/explainer.md
@@ -232,7 +232,7 @@ interface XRDepthInformation {
   readonly attribute unsigned long width;
   readonly attribute unsigned long height;
 
-  [SameObject] readonly attribute XRRigidTransform normTextureFromNormView;
+  [SameObject] readonly attribute XRRigidTransform normDepthBufferFromNormView;
   readonly attribute float rawValueToMeters;
 };
 

--- a/explainer.md
+++ b/explainer.md
@@ -34,7 +34,7 @@ Note that the usage and format preferences should omit values that the site know
 
 ```javascript
 console.log(session.depthUsage);
-console.log(session.depthFormat);
+console.log(session.depthDataFormat);
 
 // Other setup, for example prepare appropriate shader depending on
 // the depth data format if using WebGL to access the data.

--- a/explainer.md
+++ b/explainer.md
@@ -23,7 +23,7 @@ const session = await navigator.xr.requestSession(“immersive-ar”, {
   requiredFeatures: [“depth-sensing”],
   depthSensing: {
     usagePreference: ["cpu-optimized", "gpu-optimized"],
-    formatPreference: ["luminance-alpha", "float32"]
+    dataFormatPreference: ["luminance-alpha", "float32"]
   }
 });
 ```


### PR DESCRIPTION
There is a typo in the example.

It should be `dataFormatPreference`, not `formatPreference`.