### PR TITLE
Fix explainer code and add validation in GPU path

### DIFF
--- a/explainer.md
+++ b/explainer.md
@@ -59,9 +59,7 @@ Alternatively, the depth data is also available via the `depthInfo.data` attribu
 
 For example, to access the data at row `r`, column `c` of the buffer that has `"luminance-alpha"` format, the app can use:
 ```js
-const uint16Data = new Uint16Array(depthInfo.data.buffer,
-                                   depthInfo.data.byteOffset,
-                                   depthInfo.data.byteLength);
+const uint16Data = new Uint16Array(depthInfo.data);
 
 const index = c + r * depthInfo.width;
 const depthInMetres = uint16Data[index] * depthInfo.rawValueToMeters;
@@ -69,9 +67,7 @@ const depthInMetres = uint16Data[index] * depthInfo.rawValueToMeters;
 
 If the data format was set to `"float32"`, the data could be accessed similarly (note that the only difference is that the data buffer is interpreted as containing float32s):
 ```js
-const float32Data = new Float32Array(depthInfo.data.buffer,
-                                     depthInfo.data.byteOffset,
-                                     depthInfo.data.byteLength);
+const float32Data = new Float32Array(depthInfo.data);
 
 const index = c + r * depthInfo.width;
 const depthInMetres = float32Data[index] * depthInfo.rawValueToMeters;

--- a/index.bs
+++ b/index.bs
@@ -401,10 +401,10 @@ function requestAnimationFrameCallback(t, frame) {
   session.requestAnimationFrame(requestAnimationFrameCallback);
 
   const pose = frame.getViewerPose(referenceSpace);
-  if(pose) {
-    for(const view of pose.views) {
+  if (pose) {
+    for (const view of pose.views) {
       const depthInformation = frame.getDepthInformation(view);
-      if(depthInformation) {
+      if (depthInformation) {
         useCpuDepthInformation(view, depthInformation);
       }
     }
@@ -446,10 +446,11 @@ The <dfn method for="XRWebGLDepthInformation">getDepthInformation(view)</dfn> me
 
 <div class="algorithm" data-algorithm="obtain-webgl-depth-information">
 
-When {{XRWebGLBinding/getDepthInformation(view)}} method is invoked on an {{XRFrame}} |frame| with an {{XRView}} |view|, the user agent MUST <dfn>obtain WebGL depth information</dfn> by running the following steps:
+When {{XRWebGLBinding/getDepthInformation(view)}} method is invoked on a {{XRWebGLBinding}} |binding| with an {{XRView}} |view|, the user agent MUST <dfn>obtain WebGL depth information</dfn> by running the following steps:
 
+  1. Let |session| be |binding|'s [=XRWebGLBinding/session=].
   1. Let |frame| be |view|'s [=XRView/frame=].
-  1. Let |session| be |frame|'s {{XRFrame/session}}.
+  1. If |session| does not match |frame|'s {{XRFrame/session}}, throw an {{InvalidStateError}} and abort these steps.
   1. If [=depth-sensing=] feature descriptor is not [=list/contain|contained=] in the |session|'s [=XRSession/XR device=]'s [=XR device/list of enabled features=] for |session|'s [=XRSession/mode=], [=exception/throw=] a {{NotSupportedError}} and abort these steps.
   1. If the |session|'s {{XRSession/depthUsage}} is not {{XRDepthUsage/"gpu-optimized"}}, throw an {{InvalidStateError}} and abort these steps.
   1. If |frame|'s [=XRFrame/active=] boolean is <code>false</code>, throw an {{InvalidStateError}} and abort these steps.
@@ -492,10 +493,10 @@ function requestAnimationFrameCallback(t, frame) {
   session.requestAnimationFrame(requestAnimationFrameCallback);
 
   const pose = frame.getViewerPose(referenceSpace);
-  if(pose) {
-    for(const view of pose.views) {
+  if (pose) {
+    for (const view of pose.views) {
       const depthInformation = glBinding.getDepthInformation(view);
-      if(depthInformation) {
+      if (depthInformation) {
         useGpuDepthInformation(view, depthInformation);
       }
     }


### PR DESCRIPTION
Explainer relied on the sample code that worked due to a bug in Chrome's
implementation of depth sensing API. The type of `data` set on
`XRCPUDepthInformation` does not have the `buffer`, `byteOffset` and
`byteLength` attributes.

Additionally, add validation for the algorithm for
XRWebGLBinding.getDepthInformation() to ensure that the session of the
provided `XRView` matches the session of the binding itself.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/immersive-web/depth-sensing/pull/24.html" title="Last updated on Apr 8, 2021, 12:07 AM UTC (e5c3259)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/immersive-web/depth-sensing/24/0e25f64...e5c3259.html" title="Last updated on Apr 8, 2021, 12:07 AM UTC (e5c3259)">Diff</a>