### PR TITLE
added TR for bikeshed

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3,6 +3,7 @@ Shortname: webxr-depth-sensing
 Title: WebXR Depth Sensing Module
 Group: immersivewebwg
 Status: ED
+TR: https://www.w3.org/TR/webxr-depth-sensing-1/
 Level: 1
 ED: https://immersive-web.github.io/depth-sensing/
 Repository: immersive-web/depth-sensing


### PR DESCRIPTION
Added a line of TR for bikeshed configuration.

Also, there is one error of link.
```
LINE ~454: No 'dfn' refs found for 'session' that are marked for export.
```


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/himorin/webxr-depth-sensing/pull/26.html" title="Last updated on Aug 28, 2021, 12:34 PM UTC (a5620ef)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/immersive-web/depth-sensing/26/b93012c...himorin:a5620ef.html" title="Last updated on Aug 28, 2021, 12:34 PM UTC (a5620ef)">Diff</a>