### PR TITLE
added XRWebGLBinding/session anchor

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -31,8 +31,9 @@ spec: WebGL; urlPrefix: https://www.khronos.org/registry/webgl/specs/latest/1.0/
 spec: WebGL 2.0; urlPrefix: https://www.khronos.org/registry/webgl/specs/latest/2.0/#
     for: GLenum;
         type: dfn; text: R32F; url: 3.7
-spec: WebXR Layers; urlPrefix: https://immersive-web.github.io/layers/#
+spec: WebXR Layers; urlPrefix: https://www.w3.org/TR/webxrlayers-1/#
     type: dfn; text: opaque texture; url: opaque-texture
+    type: dfn; text: session; for: XRWebGLBinding; url: xrwebglbinding-session
 spec: WebXR Device API - Level 1; urlPrefix: https://www.w3.org/TR/webxr/#
     type: dfn; text: capable of supporting; url: capable-of-supporting
     type: dfn; text: feature descriptor; url: feature-descriptor


### PR DESCRIPTION
to fix bikeshed error


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/himorin/webxr-depth-sensing/pull/34.html" title="Last updated on Dec 24, 2021, 6:11 AM UTC (5507eb4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/immersive-web/depth-sensing/34/c114fc3...himorin:5507eb4.html" title="Last updated on Dec 24, 2021, 6:11 AM UTC (5507eb4)">Diff</a>