### PR TITLE
[Fix] getDepthInMeters() arguments definition

### DIFF
--- a/explainer.md
+++ b/explainer.md
@@ -236,7 +236,7 @@ interface XRCPUDepthInformation : XRDepthInformation {
   // Data format is determined by session's depthDataFormat attribute.
   [SameObject] readonly attribute ArrayBuffer data;
 
-  float getDepthInMeters(unsigned long column, unsigned long row);
+  float getDepthInMeters(float x, float y);
 };
 
 interface XRWebGLDepthInformation : XRDepthInformation {


### PR DESCRIPTION
I found `getDepthInMeters` method definition in [Web IDL](https://github.com/immersive-web/depth-sensing/blob/main/explainer.md#appendix-proposed-web-idl) not matched with [Working Draft](https://www.w3.org/TR/2022/WD-webxr-depth-sensing-1-20220419/#xr-cpu-depth-info-section).

![image](https://user-images.githubusercontent.com/11372210/206916688-81ecbd26-f3fc-43e6-9515-c69e1a0b442a.png)
![image](https://user-images.githubusercontent.com/11372210/206916698-2d13c3db-e249-424f-aec6-b133d7a5df1e.png)

I think, other parts refering to this method is correct in explaner. 