### PR TITLE
Add support for rui16 and allow empty preference

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -162,12 +162,12 @@ enum XRDepthUsage {
 enum XRDepthDataFormat {
   "luminance-alpha",
   "float32",
-  "unsigned-int",
+  "unsigned-short",
 };
 </script>
 
-- A data format of <dfn enum-value for="XRDepthDataFormat">"luminance-alpha"</dfn> or <dfn enum-value for="XRDepthDataFormat">"unsigned-int"</dfn> indicates that items in the depth data buffers obtained from the API are 2-byte unsigned integer values.
-- A data format <dfn enum-value for="XRDepthDataFormat">"float32"</dfn> indicates that items in the depth data buffers obtained from the API are 4-byte floating point values.
+- A data format of <dfn enum-value for="XRDepthDataFormat">"luminance-alpha"</dfn> or <dfn enum-value for="XRDepthDataFormat">"unsigned-short"</dfn> indicates that items in the depth data buffers obtained from the API are 16 bit unsigned integer values.
+- A data format <dfn enum-value for="XRDepthDataFormat">"float32"</dfn> indicates that items in the depth data buffers obtained from the API are 32 bit floating point values.
 
 The following table summarizes the ways various data formats can be consumed:
 
@@ -185,21 +185,21 @@ The following table summarizes the ways various data formats can be consumed:
     <tr>
       <td>{{XRDepthDataFormat/"luminance-alpha"}}</td>
       <td>[=GLenum/LUMINANCE_ALPHA=]</td>
-      <td>2 bytes</dt>
+      <td>2 times 8 bit</dt>
       <td>Interpret {{XRCPUDepthInformation/data}} as {{Uint16Array}}</td>
       <td>Inspect Luminance and Alpha channels to reassemble single value.</td>
     </tr>
     <tr>
       <td>{{XRDepthDataFormat/"float32"}}</td>
       <td>[=GLenum/R32F=]</td>
-      <td>4 bytes</dt>
+      <td>32 bit</dt>
       <td>Interpret {{XRCPUDepthInformation/data}} as {{Float32Array}}</td>
       <td>Inspect Red channel and use the value.</td>
     </tr>
     <tr>
-      <td>{{XRDepthDataFormat/"unsigned-int"}}</td>
+      <td>{{XRDepthDataFormat/"unsigned-short"}}</td>
       <td>[=GLenum/R16UI=]</td>
-      <td>2 bytes</dt>
+      <td>16 bit</dt>
       <td>Interpret {{XRCPUDepthInformation/data}} as {{Uint16Array}}</td>
       <td>Inspect Red channel and use the value.</td>
     </tr>
@@ -238,16 +238,26 @@ When an {{XRSession}} is created with depth sensing enabled, the {{XRSession/dep
 In order to <dfn>find supported configuration combination</dfn> for depth sensing API given |usagePreference| and |dataFormatPreference| sequences, the user agent MUST run the following algorithm:
 
   1. Let |selectedUsage| be <code>null</code>.
-  1. If the |usagePreference| sequence is empty, set |selectedUsage| to the device's preferred [=native depth sensing=] capability.
-  1. For each |usage| in |usagePreference| sequence, perform the following steps:
-    1. If |usage| is not considered a <a lt="support depth sensing usage">supported depth sensing usage</a> by the [=native depth sensing=] capabilities of the device, continue to the next entry.
-    1. Set |selectedUsage| to |usage| and abort these nested steps.
+  1. Initialize |selectedUsage| as follows:
+    <dl class="switch">
+      <dt class="switch">If the |usagePreference| sequence is empty
+        <dd> Initialize |selectedUsage| to the device's preferred [=native depth sensing=] capability.
+      <dt> Otherwise
+        <dd>  For each |usage| in |usagePreference| sequence, perform the following steps:
+          1. If |usage| is not considered a <a lt="support depth sensing usage">supported depth sensing usage</a> by the [=native depth sensing=] capabilities of the device, continue to the next entry.
+          1. Set |selectedUsage| to |usage| and abort these nested steps.
+      </dl>
   1. If |selectedUsage| is <code>null</code>, return <code>null</code> and abort these steps.
   1. Let |selectedDataFormat| be <code>null</code>.
-  1. If the |dataFormatPreference| sequence is empty, set |selectedDataFormat| to the device's preferred [=native depth sensing=] format.
-  1. For each |dataFormat| in |dataFormatPreference|, perform the following steps:
-    1. If |selectedUsage|,|dataFormat| is not considered a <a lt="support depth sensing usage and data format combination">supported depth sensng usage and data format combination</a> by the [=native depth sensing=] capabilities of the device, continue to the next entry.
-    1. Set |selectedDataFormat| to |dataFormat| and abort these nested steps.
+  1. Initialize |selectedDataFormat| as follows:
+    <dl class="switch">
+      <dt class="switch">If the |usagePreference| sequence is empty
+        <dd> Initialize |selectedDataFormat| to the device's preferred [=native depth sensing=] format.
+      <dt> Otherwise
+        <dd>  For each |dataFormat| in |dataFormatPreference|, perform the following steps:
+          1. If |selectedUsage|,|dataFormat| is not considered a <a lt="support depth sensing usage and data format combination">supported depth sensng usage and data format combination</a> by the [=native depth sensing=] capabilities of the device, continue to the next entry.
+          1. Set |selectedDataFormat| to |dataFormat| and abort these nested steps.
+      </dl>
   1. If |selectedDataFormat| is <code>null</code>, return <code>null</code> and abort these steps.
   1. Return |selectedUsage|,|selectedDataFormat|.
 
@@ -642,7 +652,7 @@ The device can <dfn>support depth sensing usage</dfn> in 2 ways. If the device i
 
 Note: The user agent can choose to support both usage modes (e.g. when the device is capable of providing both CPU- and GPU-accessible data, or by performing the transfer between CPU- and GPU-accessible data manually).
 
-The device can <dfn>support depth sensing data format</dfn> given depth sensing usage in the following ways. If, given the depth sensing usage, the device is able to return depth data as a buffer containing 2-byte unsigned integers, it is said to support the {{XRDepthDataFormat/"luminance-alpha"}} or {{XRDepthDataFormat/"unsigned-int"}} data format. If, given the depth sensing usage, the device is able to return depth data as a buffer containing 4-byte floating point values, it is said to support the {{XRDepthDataFormat/"float32"}} data format.
+The device can <dfn>support depth sensing data format</dfn> given depth sensing usage in the following ways. If, given the depth sensing usage, the device is able to return depth data as a buffer containing 16 bit unsigned integers, it is said to support the {{XRDepthDataFormat/"luminance-alpha"}} or {{XRDepthDataFormat/"unsigned-short"}} data format. If, given the depth sensing usage, the device is able to return depth data as a buffer containing 32 bit floating point values, it is said to support the {{XRDepthDataFormat/"float32"}} data format.
 
 The device is said to <dfn>support depth sensing usage and data format combination</dfn> if it <a lt="support depth sensing usage">supports depth sensing usage</a> and <a lt="support depth sensing data format">supports depth sensing data format</a> given the specified usage.
 

--- a/index.bs
+++ b/index.bs
@@ -241,7 +241,7 @@ In order to <dfn>find supported configuration combination</dfn> for depth sensin
   1. Initialize |selectedUsage| as follows:
     <dl class="switch">
       <dt class="switch">If the |usagePreference| sequence is empty
-        <dd> Initialize |selectedUsage| to the device's preferred [=native depth sensing=] capability.
+        <dd> Initialize |selectedUsage| to the device's [=preferred native depth sensing capability=].
       <dt> Otherwise
         <dd>  For each |usage| in |usagePreference| sequence, perform the following steps:
           1. If |usage| is not considered a <a lt="support depth sensing usage">supported depth sensing usage</a> by the [=native depth sensing=] capabilities of the device, continue to the next entry.
@@ -252,7 +252,7 @@ In order to <dfn>find supported configuration combination</dfn> for depth sensin
   1. Initialize |selectedDataFormat| as follows:
     <dl class="switch">
       <dt class="switch">If the |usagePreference| sequence is empty
-        <dd> Initialize |selectedDataFormat| to the device's preferred [=native depth sensing=] format.
+        <dd> Initialize |selectedDataFormat| to the device's [=preferred native depth sensing format=].
       <dt> Otherwise
         <dd>  For each |dataFormat| in |dataFormatPreference|, perform the following steps:
           1. If |selectedUsage|,|dataFormat| is not considered a <a lt="support depth sensing usage and data format combination">supported depth sensng usage and data format combination</a> by the [=native depth sensing=] capabilities of the device, continue to the next entry.
@@ -657,6 +657,8 @@ The device can <dfn>support depth sensing data format</dfn> given depth sensing 
 The device is said to <dfn>support depth sensing usage and data format combination</dfn> if it <a lt="support depth sensing usage">supports depth sensing usage</a> and <a lt="support depth sensing data format">supports depth sensing data format</a> given the specified usage.
 
 Note: the support of depth sensing API is not limited only to hardware classified as AR-capable, although it is expected that the feature will be more common in such devices. VR devices that contain appropriate sensors and/or use other techniques to provide depth buffer should also be able to provide the data necessary to implement depth sensing API.
+
+The device MUST have a <dfn>preferred [=native depth sensing=] capability</dfn> that MUST be used if the {{XRDepthStateInit/usagePreference}} array is empty, and a <dfn>preferred [=native depth sensing=] format</dfn> that MUST be used if the {{XRDepthStateInit/dataFormatPreference}} array is empty. The capability and format SHOULD reflect the most efficient ones of the device.
 
 </section>
 

--- a/index.bs
+++ b/index.bs
@@ -33,6 +33,8 @@ spec: WebGL 2.0; urlPrefix: https://www.khronos.org/registry/webgl/specs/latest/
     for: GLenum;
         type: dfn; text: R32F; url: 3.7
     type: typedef; text: TEXTURE_2D_ARRAY; url: 3.7
+    for: GLenum;
+        type: dfn; text: R16UI; url: 3.7
 spec: WebXR Layers; urlPrefix: https://www.w3.org/TR/webxrlayers-1/#
     type: dfn; text: opaque texture; url: opaque-texture
     type: dfn; text: session; for: XRWebGLBinding; url: xrwebglbinding-session
@@ -159,11 +161,12 @@ enum XRDepthUsage {
 <script type="idl">
 enum XRDepthDataFormat {
   "luminance-alpha",
-  "float32"
+  "float32",
+  "unsigned-int",
 };
 </script>
 
-- A data format of <dfn enum-value for="XRDepthDataFormat">"luminance-alpha"</dfn> indicates that items in the depth data buffers obtained from the API are 2-byte unsigned integer values.
+- A data format of <dfn enum-value for="XRDepthDataFormat">"luminance-alpha"</dfn> or <dfn enum-value for="XRDepthDataFormat">"unsigned-int"</dfn> indicates that items in the depth data buffers obtained from the API are 2-byte unsigned integer values.
 - A data format <dfn enum-value for="XRDepthDataFormat">"float32"</dfn> indicates that items in the depth data buffers obtained from the API are 4-byte floating point values.
 
 The following table summarizes the ways various data formats can be consumed:
@@ -191,6 +194,13 @@ The following table summarizes the ways various data formats can be consumed:
       <td>[=GLenum/R32F=]</td>
       <td>4 bytes</dt>
       <td>Interpret {{XRCPUDepthInformation/data}} as {{Float32Array}}</td>
+      <td>Inspect Red channel and use the value.</td>
+    </tr>
+    <tr>
+      <td>{{XRDepthDataFormat/"unsigned-int"}}</td>
+      <td>[=GLenum/R16UI=]</td>
+      <td>2 bytes</dt>
+      <td>Interpret {{XRCPUDepthInformation/data}} as {{Uint16Array}}</td>
       <td>Inspect Red channel and use the value.</td>
     </tr>
   </tbody>
@@ -228,11 +238,13 @@ When an {{XRSession}} is created with depth sensing enabled, the {{XRSession/dep
 In order to <dfn>find supported configuration combination</dfn> for depth sensing API given |usagePreference| and |dataFormatPreference| sequences, the user agent MUST run the following algorithm:
 
   1. Let |selectedUsage| be <code>null</code>.
+  1. If the |usagePreference| sequence is empty, set |selectedUsage| to the device's preferred [=native depth sensing=] capability.
   1. For each |usage| in |usagePreference| sequence, perform the following steps:
     1. If |usage| is not considered a <a lt="support depth sensing usage">supported depth sensing usage</a> by the [=native depth sensing=] capabilities of the device, continue to the next entry.
     1. Set |selectedUsage| to |usage| and abort these nested steps.
   1. If |selectedUsage| is <code>null</code>, return <code>null</code> and abort these steps.
   1. Let |selectedDataFormat| be <code>null</code>.
+  1. If the |dataFormatPreference| sequence is empty, set |selectedDataFormat| to the device's preferred [=native depth sensing=] format.
   1. For each |dataFormat| in |dataFormatPreference|, perform the following steps:
     1. If |selectedUsage|,|dataFormat| is not considered a <a lt="support depth sensing usage and data format combination">supported depth sensng usage and data format combination</a> by the [=native depth sensing=] capabilities of the device, continue to the next entry.
     1. Set |selectedDataFormat| to |dataFormat| and abort these nested steps.
@@ -630,7 +642,7 @@ The device can <dfn>support depth sensing usage</dfn> in 2 ways. If the device i
 
 Note: The user agent can choose to support both usage modes (e.g. when the device is capable of providing both CPU- and GPU-accessible data, or by performing the transfer between CPU- and GPU-accessible data manually).
 
-The device can <dfn>support depth sensing data format</dfn> given depth sensing usage in the following ways. If, given the depth sensing usage, the device is able to return depth data as a buffer containing 2-byte unsigned integers, it is said to support {{XRDepthDataFormat/"luminance-alpha"}} data format. If, given the depth sensing usage, the device is able to return depth data as a buffer containing 4-byte floating point values, it is said to support {{XRDepthDataFormat/"float32"}} data format.
+The device can <dfn>support depth sensing data format</dfn> given depth sensing usage in the following ways. If, given the depth sensing usage, the device is able to return depth data as a buffer containing 2-byte unsigned integers, it is said to support the {{XRDepthDataFormat/"luminance-alpha"}} or {{XRDepthDataFormat/"unsigned-int"}} data format. If, given the depth sensing usage, the device is able to return depth data as a buffer containing 4-byte floating point values, it is said to support the {{XRDepthDataFormat/"float32"}} data format.
 
 The device is said to <dfn>support depth sensing usage and data format combination</dfn> if it <a lt="support depth sensing usage">supports depth sensing usage</a> and <a lt="support depth sensing data format">supports depth sensing data format</a> given the specified usage.
 


### PR DESCRIPTION
- as discussed in today's meeting, I added support for an empty array to indicate that the author has no preference and wants the optimal preferences for the current platform
- add another format option which matches Quest browser's implementation

@bialpio , should I define the definitions of the user agent's preferred format and usage?
Also, luminance-alpha and unsigned-int are very similar. Is there a reason you chose luminance-alpha?


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/cabanier/depth-sensing/pull/49.html" title="Last updated on May 31, 2024, 5:07 PM UTC (1d185b8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/immersive-web/depth-sensing/49/d703f27...cabanier:1d185b8.html" title="Last updated on May 31, 2024, 5:07 PM UTC (1d185b8)">Diff</a>