### PR TITLE
Update requirements when view is aligned

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -388,7 +388,7 @@ The {{XRDepthInformation/rawValueToMeters}} attribute contains the scale factor 
 
 The {{XRViewGeometry/transform}} is given in the associated [=XRDepthInformation/view=]'s [=view/reference space=].
 
-If the [=XRDepthInformation/sensor=] is aligned with the associated [=XRDepthInformation/view=], the {{XRViewGeometry/transform}} and {{XRViewGeometry/projectionMatrix}} MUST be equivalent to the identity transform. These attributes MAY otherwise be used by experiences to better align with the real world.
+If the [=XRDepthInformation/sensor=] is aligned with the associated [=XRDepthInformation/view=], then all values included from {{XRViewGeometry}} MUST return the same values as the associated [=XRDepthInformation/view=] does.
 
 Each {{XRDepthInformation}} has an associated <dfn for=XRDepthInformation>view</dfn> which is the closest {{XRView}} to the [=XRDepthInformation/sensor=], and is used to retrieve the {{XRDepthInformation}}.
 


### PR DESCRIPTION
Rather than identity, assert that the XRViewGeometry equals that of the containing view.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/immersive-web/depth-sensing/pull/62.html" title="Last updated on May 1, 2025, 6:01 PM UTC (739db17)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/immersive-web/depth-sensing/62/df9b71e...739db17.html" title="Last updated on May 1, 2025, 6:01 PM UTC (739db17)">Diff</a>